### PR TITLE
README and Vagrantfile refreshed and simplified

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,11 @@ You should also verify each host can access etcd.  The following will return an 
 
     curl -L http://localhost:4001/version
 
-## Setting up Calico
+## Try out Calico Networking
 
-Now that you have a two-node cluster, you can configure Calico on the nodes and begin networking containers by visiting the [Getting Started][using-calico] page.
+Now you have a basic two node CoreOS cluster setup and you are ready to try Calico neworking.
+
+Follow the step by step [Getting Started][using-calico] instructions in the main calico-docker repo.
 
 [calico-ubuntu-vagrant]: https://github.com/Metaswitch/calico-ubuntu-vagrant-example
 [virtualbox]: https://www.virtualbox.org/

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 This example shows how to network Docker containers using Calico with Docker's new [libnetwork network driver support](https://github.com/docker/libnetwork) that was introduced on the Docker [experimental channel](https://github.com/docker/docker/tree/master/experimental) alongside the Docker 1.7 release.  Docker's experimental channel is moving fast and some of its features are not yet fully stable.  For this reason this vagrant example currently uses a specific Docker experimental build with a specific build of Calico (rather than tracking master in both the [docker](https://github.com/docker/docker) and [calico-docker](https://github.com/Metaswitch/calico-docker) repos).
 
-For a more stable version of Calico's integration with Docker, see [the main project page](https://github.com/Metaswitch/calico-docker) for examples based on Powerstrip.
+For a more stable version of Calico's integration with Docker, see [the Calico CoreOS example](https://github.com/Metaswitch/calico-coreos-vagrant-example) based on Powerstrip.
 
 ### A note about names & addresses
 In this example, we will use the following server names and IP addresses.
 
-| hostname   | IP address   |
-|------------|--------------|
+| hostname  | IP address   |
+|-----------|--------------|
 | ubuntu-0  | 172.17.8.100 |
 | ubuntu-1  | 172.17.8.101 |
 
@@ -76,84 +76,9 @@ You should also verify each host can access etcd.  The following will return an 
 
     curl -L http://localhost:4001/version
 
-## Starting Calico services<a id="calico-services"></a>
+## Setting up Calico
 
-Once you have your cluster up and running, start calico on all the nodes
-
-On ubuntu-0
-
-    sudo ./calicoctl node --ip=172.17.8.100 --node-image=calico/node:libnetwork
-
-On ubuntu-1
-
-    sudo ./calicoctl node --ip=172.17.8.101 --node-image=calico/node:libnetwork
-
-This will start a container. Check they are running
-
-    docker ps
-
-You should see output like this on each node
-
-    vagrant@ubuntu-1:~$ docker ps -a
-    CONTAINER ID        IMAGE                    COMMAND                CREATED             STATUS              PORTS                                            NAMES
-    39de206f7499        calico/node:libnetwork   "/sbin/my_init"        2 minutes ago       Up 2 minutes                                                         calico-node
-    5e36a7c6b7f0        quay.io/coreos/etcd      "/etcd --name calico   30 minutes ago      Up 30 minutes       0.0.0.0:4001->4001/tcp, 0.0.0.0:7001->7001/tcp   quay.io-coreos-etcd
-
-## Creating networked endpoints
-
-The experimantal channel version of Docker introduces a new flag to `docker run` to network containers:  `--publish-service <service>.<network>.<driver>`.
-
- * `<service>` is the name by which you want the container to be known on the network.
- * `<network>` is the name of the network to join.  Containers on different networks cannot communicate.
- * `<driver>` is the name of the network driver to use.  Calico's driver is called `calico`.
-
-So let's go ahead and start a few of containers on each host.
-
-On ubuntu-0
-
-    docker run --publish-service srvA.net1.calico --name workload-A -tid busybox
-    docker run --publish-service srvB.net2.calico --name workload-B -tid busybox
-    docker run --publish-service srvC.net1.calico --name workload-C -tid busybox
-
-On ubuntu-1
-
-    docker run --publish-service srvD.net3.calico --name workload-D -tid busybox
-    docker run --publish-service srvE.net1.calico --name workload-E -tid busybox
-
-By default, networks are configured so that their members can communicate with one another, but workloads in other networks cannot reach them.  A, C and E are all in the same network so should be able to ping each other.  B and D are in their own networks so shouldn't be able to ping anyone else.
-
-You can find out a container's IP by running
-
-    docker inspect --format "{{ .NetworkSettings.IPAddress }}" <container name>
-
-On ubuntu-0, find out the IP addresses of A, B and C.
-
-    docker inspect --format "{{ .NetworkSettings.IPAddress }}" workload-A
-    docker inspect --format "{{ .NetworkSettings.IPAddress }}" workload-B
-    docker inspect --format "{{ .NetworkSettings.IPAddress }}" workload-C
-    
-On ubuntu-1, find out the IP addresses of D and E.
-
-    docker inspect --format "{{ .NetworkSettings.IPAddress }}" workload-D
-    docker inspect --format "{{ .NetworkSettings.IPAddress }}" workload-E
-    
-Now we know all the IP addresses, on ubuntu-0 check that A can ping C and E (substitute the IP addresses as required).
-
-    docker exec workload-A ping -c 4 192.168.0.3
-    docker exec workload-A ping -c 4 192.168.0.5
-
-Also check that A cannot ping B or D (substitute the IP addresses as required).
-
-    docker exec workload-A ping -c 4 192.168.0.2
-    docker exec workload-A ping -c 4 192.168.0.4
-
-Libnetwork also supports using published service names.  However, note that in the current build of libnetwork these are not yet reliable in multi-host deployments.  On ubuntu-0 try
-
-    docker exec workload-A ping -c 4 srvC
-
-To see the list of networks, use
-
-    docker network ls
+Now that you have a two-node cluster, you can configure Calico on the nodes and begin networking containers by visiting the [Getting Started][using-calico] page.
 
 [calico-ubuntu-vagrant]: https://github.com/Metaswitch/calico-ubuntu-vagrant-example
 [virtualbox]: https://www.virtualbox.org/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -70,19 +70,19 @@ Vagrant.configure(2) do |config|
       end
 
       # download calico and preload the docker images.
-      host.vm.provision :shell, inline: "wget -q https://circle-artifacts.com/gh/Metaswitch/calico-docker/1128/artifacts/0/home/ubuntu/calico-docker/dist/calicoctl"
+      host.vm.provision :shell, inline: "wget -q https://github.com/Metaswitch/calico-docker/releases/download/v0.5.0/calicoctl"
       host.vm.provision :shell, inline: "chmod +x calicoctl"
-      host.vm.provision :shell, inline: "sudo ./calicoctl checksystem --fix"
       host.vm.provision :docker, images: [
           "busybox:latest",
-          "calico/node:libnetwork",
+          "calico/node:v0.5.0",
           "quay.io/coreos/etcd:v2.0.11",
       ]
+      host.vm.provision :shell, inline: "sudo ./calicoctl checksystem --fix"
 
       # Replace docker with an unreleased version.
-      filename = "docker"
-      host.vm.provision :shell, inline: "wget https://transfer.sh/jjSCh/#{filename} > /dev/null 2>&1"
-      # host.vm.provision :shell, inline: "wget https://master.dockerproject.org/linux/amd64/docker-1.7.0-dev > /dev/null"
+      filename = "docker-1.8.0-dev"
+      host.vm.provision :shell, inline: "wget https://github.com/Metaswitch/calico-docker/releases/download/v0.5.0/#{filename}.gz > /dev/null 2>&1"
+      host.vm.provision :shell, inline: "gunzip -c #{filename}.gz > #{filename}"
       host.vm.provision :shell, inline: "chmod +x #{filename}"
       host.vm.provision :shell, inline: "sudo stop docker"
       host.vm.provision :shell, inline: "sudo cp #{filename} $(which docker)"

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -64,12 +64,15 @@ Vagrant.configure(2) do |config|
       ip = "172.17.8.#{i+100}"
       host.vm.network :private_network, ip: ip
 
+      config.vm.provision "fix-no-tty", type: "shell" do |s|
+        s.privileged = false
+        s.inline = "sudo sed -i '/tty/!s/mesg n/tty -s \\&\\& mesg n/' /root/.profile"
+      end
+
       # download calico and preload the docker images.
-      host.vm.provision :shell, inline: "wget -q https://circle-artifacts.com/gh/Metaswitch/calico-docker/962/artifacts/0/home/ubuntu/calico-docker/dist/calicoctl"
+      host.vm.provision :shell, inline: "wget -q https://circle-artifacts.com/gh/Metaswitch/calico-docker/1128/artifacts/0/home/ubuntu/calico-docker/dist/calicoctl"
       host.vm.provision :shell, inline: "chmod +x calicoctl"
-      host.vm.provision :shell, inline: "sudo modprobe ip6_tables"
-      host.vm.provision :shell, inline: "sudo modprobe xt_set"
-      host.vm.provision :shell, inline: "sudo sysctl -w net.ipv6.conf.all.forwarding=1"
+      host.vm.provision :shell, inline: "sudo ./calicoctl checksystem --fix"
       host.vm.provision :docker, images: [
           "busybox:latest",
           "calico/node:libnetwork",
@@ -78,8 +81,7 @@ Vagrant.configure(2) do |config|
 
       # Replace docker with an unreleased version.
       filename = "docker"
-      host.vm.provision :shell, inline: "wget https://transfer.sh/iSKTe/#{filename}.tgz > /dev/null 2>&1"
-      host.vm.provision :shell, inline: "tar -zxvf #{filename}.tgz"
+      host.vm.provision :shell, inline: "wget https://transfer.sh/jjSCh/#{filename} > /dev/null 2>&1"
       # host.vm.provision :shell, inline: "wget https://master.dockerproject.org/linux/amd64/docker-1.7.0-dev > /dev/null"
       host.vm.provision :shell, inline: "chmod +x #{filename}"
       host.vm.provision :shell, inline: "sudo stop docker"


### PR DESCRIPTION
The demo now simply creates the two-node ubuntu cluster.  The Getting Started guide in calico-docker has been updated to include the additional configurations for setting up Calico networking.